### PR TITLE
Added highlighting and render target support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { Color } from 'three';
+import { Color, Vector4 } from 'three';
 
 export const DEFAULT_RGB_BRIGHTNESS = 0;
 export const DEFAULT_RGB_CONTRAST = 0;
@@ -12,3 +12,4 @@ export const MAX_LOADS_TO_GPU = 2;
 export const MAX_NUM_NODES_LOADING = 4;
 export const PERSPECTIVE_CAMERA = 'PerspectiveCamera';
 export const COLOR_BLACK = new Color(0, 0, 0);
+export const DEFAULT_HIGHLIGHT_COLOR = new Vector4(1, 0, 0, 1);

--- a/src/materials/shaders/pointcloud.frag
+++ b/src/materials/shaders/pointcloud.frag
@@ -21,6 +21,10 @@ uniform float screenHeight;
 
 uniform sampler2D depthMap;
 
+#ifdef highlight_point
+	uniform vec4 highlightedPointColor;
+#endif
+
 varying vec3 vColor;
 
 #if !defined(color_type_point_index)
@@ -47,6 +51,10 @@ varying vec3 vColor;
 	varying vec3 vNormal;
 #endif
 
+#ifdef highlight_point
+	varying float vHighlight;
+#endif
+
 float specularStrength = 1.0;
 
 void main() {
@@ -64,7 +72,7 @@ void main() {
 			discard;
 		}
 	#endif
-	
+
 	#if defined weighted_splats
 		vec2 uv = gl_FragCoord.xy / vec2(screenWidth, screenHeight);
 		float sDepth = texture2D(depthMap, uv).r;
@@ -240,5 +248,11 @@ void main() {
 		#if defined(use_edl)
 			gl_FragColor.a = vLogDepth;
 		#endif
-	#endif	
+	#endif
+
+	#ifdef highlight_point
+		if (vHighlight > 0.0) {
+			gl_FragColor = highlightedPointColor;
+		}
+	#endif
 }

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -66,6 +66,12 @@ uniform sampler2D gradient;
 uniform sampler2D classificationLUT;
 uniform sampler2D depthMap;
 
+#ifdef highlight_point
+	uniform vec3 highlightedPointCoordinate;
+	uniform bool enablePointHighlighting;
+	uniform float highlightedPointScale;
+#endif
+
 varying vec3 vColor;
 
 #if !defined(color_type_point_index)
@@ -92,6 +98,9 @@ varying vec3 vColor;
 	varying vec3 vNormal;
 #endif
 
+#ifdef highlight_point
+	varying float vHighlight;
+#endif
 
 // ---------------------
 // OCTREE
@@ -412,8 +421,25 @@ void main() {
 	#if defined(weighted_splats) || defined(paraboloid_point_shape)
 		vRadius = pointSize / projFactor;
 	#endif
-	
+
 	gl_PointSize = pointSize;
+
+	// ---------------------
+	// HIGHLIGHTING
+	// ---------------------
+
+	#ifdef highlight_point
+		vec4 mPosition = modelMatrix * vec4(position, 1.0);
+		if (enablePointHighlighting && abs(mPosition.x - highlightedPointCoordinate.x) < 0.0001 &&
+			abs(mPosition.y - highlightedPointCoordinate.y) < 0.0001 &&
+			abs(mPosition.z - highlightedPointCoordinate.z) < 0.0001) {
+			vHighlight = 1.0;
+			gl_PointSize = pointSize * highlightedPointScale;
+		}
+		else {
+			vHighlight = 0.0;
+		}
+	#endif
 
 	// ---------------------
 	// OPACITY

--- a/src/materials/shaders/pointcloud.vert
+++ b/src/materials/shaders/pointcloud.vert
@@ -435,8 +435,7 @@ void main() {
 			abs(mPosition.z - highlightedPointCoordinate.z) < 0.0001) {
 			vHighlight = 1.0;
 			gl_PointSize = pointSize * highlightedPointScale;
-		}
-		else {
+		} else {
 			vHighlight = 0.0;
 		}
 	#endif


### PR DESCRIPTION
In the fragment shader and vertex shader added a `highlightPointColor`, `highlightPointCoordinate` and `highlightedPointScale` uniform to set the point highlight color, position and scale. Also added a uniform `enablePointHighlighting` to toggle point highlighting if `highlight_point` define is enabled.

Also added a define called `highlight_point` in the shader which `ifdefs` the highlighting code.

Added `RenderTarget` size support when updating point clouds